### PR TITLE
Assigning the severity parameter in Exception constructor

### DIFF
--- a/src/Exceptions/Exception.php
+++ b/src/Exceptions/Exception.php
@@ -150,6 +150,9 @@ class Exception extends CoreException implements HttpExceptionInterface
         // Set report state
         $this->setReport($report);
 
+        // Set serverity
+        $this->setSeverity($severity);
+
         // Set an empty message bag
         $this->setErrors(new MessageBag);
     }


### PR DESCRIPTION
The exception severity parameter is now set correctly